### PR TITLE
セッションのタイトルを最初のプロンプトから付ける

### DIFF
--- a/.claude/hooks/llm-session-title.sh
+++ b/.claude/hooks/llm-session-title.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Claude Code UserPromptSubmit フック: プロンプトの内容からセッションタイトルを生成する
+#
+# 生成は裏で走らせ、次にフックが発火したときに結果を返す。
+# sessionTitle は SessionStart でも受け取れるが、そちらの経路は currentSessionTitle を
+# メモリに置くだけで transcript に残らず、さらに agent name まで上書きするので使わない
+
+input=$(cat)
+
+# 生成側は disableAllHooks でフックを止めているが、設定の取りこぼしに備えて二重にする
+if [ -n "${TITLE_HOOK_ACTIVE:-}" ]; then
+  exit 0
+fi
+
+# headless 実行 (claude -p, SDK) では CLAUDE_CODE_ENTRYPOINT が sdk-* / local-agent になる
+case "${CLAUDE_CODE_ENTRYPOINT:-}" in
+  sdk-* | local-agent)
+    exit 0
+    ;;
+esac
+
+session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+if [ -z "$session_id" ]; then
+  exit 0
+fi
+# キャッシュのパスに埋めるので、UUID にない文字が来たら触らない
+case "$session_id" in
+  *[!a-zA-Z0-9_-]*)
+    exit 0
+    ;;
+esac
+
+# session_title は /rename で付けた名前とこのフックが付けた名前で非空になる
+session_title=$(printf '%s' "$input" | jq -r '.session_title // empty')
+if [ -n "$session_title" ]; then
+  exit 0
+fi
+
+cache_dir="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/claude-title-hook"
+mkdir -p "$cache_dir" || exit 0
+# 他人が先に置いていたディレクトリなら使わない (mkdir -p は既存ディレクトリでも成功する)
+if [ ! -O "$cache_dir" ] || [ -L "$cache_dir" ]; then
+  exit 0
+fi
+# mkdir -m のモードは作成時にしか効かないので、既存ディレクトリは chmod で締める
+chmod 700 "$cache_dir" || exit 0
+
+cache="$cache_dir/$session_id"
+pending="$cache.pending"
+
+if [ -s "$cache" ]; then
+  jq -n --arg title "$(cat "$cache")" '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      sessionTitle: $title
+    }
+  }'
+  exit 0
+fi
+
+# pending があるのは生成中か、直近で生成に失敗したとき。5分が再試行の間隔になる
+if [ -n "$(find "$pending" -mmin -5 2>/dev/null)" ]; then
+  exit 0
+fi
+
+prompt=$(printf '%s' "$input" | jq -r '.prompt // empty | .[0:2000]')
+if [ -z "$prompt" ]; then
+  exit 0
+fi
+
+: > "$pending"
+
+# wip 等のフックが発火して、その出力がタイトルに混ざるのを防ぐ。
+# ツールは塞がない。issue の URL だけを貼ったプロンプトでは、本文を読まないとタイトルにならない
+generator_settings='{"disableAllHooks": true}'
+
+# 切り離した claude -p がハングしたまま残らないように上限を付ける (timeout が無ければ諦める)
+limit=()
+for candidate in timeout gtimeout; do
+  if command -v "$candidate" > /dev/null 2>&1; then
+    limit=("$candidate" -k 10 180)
+    break
+  fi
+done
+
+# --strict-mcp-config: MCP サーバの起動を省く
+# 子プロセスが stdout を握ったままだと本体がフックの終了を待つので、fd は全て切り離す
+(
+  title=$(TITLE_HOOK_ACTIVE=1 "${limit[@]}" claude -p \
+    --model sonnet \
+    --no-session-persistence \
+    --strict-mcp-config \
+    --settings "$generator_settings" \
+    "以下はコーディングセッションの最初のプロンプトです。このセッションを一覧から見分けるための短いタイトルを1つだけ出力してください。タイトルは必ず日本語で20文字以内。記号や引用符は不要、タイトル以外は一切出力しないでください。
+
+URL や issue 番号だけが書かれている場合は、参照先を読んでタイトルを決めてください。
+やってよいのは読み取りだけです。ファイルの作成・編集・削除、git の操作、コメントの投稿など、状態を変える操作はしないでください。
+
+プロンプト:
+$prompt" 2> "$cache.err" | grep -m1 '[^[:space:]]')
+  # 前置きや拒否文が1行目に来ることがある。指示した20文字の倍を超えたら捨てて次回に回す
+  if [ -n "$title" ] && [ "$(printf '%s' "$title" | jq -Rs 'length')" -le 40 ] &&
+    printf '%s' "$title" > "$cache.$$.tmp" && mv "$cache.$$.tmp" "$cache"; then
+    rm -f "$pending" "$cache.err"
+  else
+    # pending の mtime は生成開始時なので、失敗時点から5分空けるために打ち直す
+    rm -f "$cache.$$.tmp"
+    touch "$pending"
+  fi
+) < /dev/null > /dev/null 2>&1 &

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/dotfiles/.claude/hooks/llm-session-title.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
セッション一覧がどれも `<ディレクトリ名>-<2文字>` で、どれが何の作業だったのか見分けられない。最初のプロンプトから Sonnet に短い日本語のタイトルを書かせ、`hookSpecificOutput.sessionTitle` で返す `UserPromptSubmit` フックを追加する。

フックは `~/.claude/hooks/` に symlink を張らず、`~/dotfiles` 配下のパスを直接指す。`~/.claude/hooks/` は実ディレクトリとして既にあって (symlink なのは `~/.claude/skills` だけ)、`install.rb` もリポジトリが `~/dotfiles` にある前提で書かれているため。

## タイトルを待たない

生成は切り離したサブシェルに投げ、結果を `$XDG_RUNTIME_DIR` (無ければ `$TMPDIR`、それも無ければ `/tmp`) 配下のキャッシュに置く。次のプロンプトでそのキャッシュを読んで返す。フック自体はどの経路も 70ms 程度で終わるので、プロンプトの送信は止まらない。タイトルが付くのは2発目以降になる。

サブシェルには `< /dev/null > /dev/null 2>&1` を与える。子プロセスが継承した stdout を握ったままだと、本体がフックの終了を待ち続ける。

素直に見える方法が2つあるが、どちらも使えない。

- **フックの `"async": true`**。ランタイムはプロセスをバックグラウンドに送った時点で `{stdout:"", stderr:"", output:"", status:0, backgrounded:true}` を返すので、`hookSpecificOutput` を解析するハンドラに到達しない。stdout の1行目に `{"async":true}` を出すプロトコルも同じで、バックグラウンド化したフックの出力を読むのは `asyncRewake` だけ。これは exit code 2 でモデルを起こす仕組みで、タイトルは設定できない。
- **Claude のターン終了時に反映する**。`sessionTitle` を読むイベントは2つだけ。

  ```js
  case"UserPromptSubmit": ... u.sessionTitle=e.hookSpecificOutput.sessionTitle ...
  case"SessionStart":     ... u.sessionTitle=e.hookSpecificOutput.sessionTitle ...
  case"Stop":case"SubagentStop": u.additionalContext=e.hookSpecificOutput.additionalContext;
  ```

`SessionStart` も反映点として試したが外した。2つの経路が等価ではないため。`UserPromptSubmit` は `Sxi()` → `utr(r,"hook")` と進んで transcript に `custom-title` を追記する。`SessionStart` は `urr()` を通り、ログに `Hook sessionTitle cached` を出してメモリだけを書く (`qXe()` が `currentSessionTitle`、`Nsr()` が `currentSessionAgentName` をタイトルで上書きする。後者は `UserPromptSubmit` 経路には無い副作用)。transcript に何も残らないので、次に resume したときタイトルは消えている。さらに `currentSessionTitle` が埋まった結果、続く `UserPromptSubmit` は rename ガードで抜けるので、永続化する経路が二度と走らない。`/clear` は新しい session id を割り当てるのでキャッシュにも当たらない。

## 生成しない条件

- **手で付けた名前があるとき**。payload の `session_title` が `/rename` を捕まえる。それらしく見える `session_name` はここには無く、statusLine の payload にあるフィールド。`Z0()` は `currentSessionTitle` だけを返し、組み込みの AI タイトルは `currentSessionAiTitle` に入るので、非空かどうかを見れば足りる。自動生成の `<ディレクトリ名>-<2文字>` という形を見分ける必要はない。`claude -n` で付けた名前は payload に載らないので、フックからは検出できない。
- **headless 実行のとき**。`CLAUDE_CODE_ENTRYPOINT` が `sdk-*` か `local-agent` になる。この判定が無いと、シェルから打った `claude -p "say OK"` が26秒かかって、誰も見ないセッションのタイトルを作る。`!= cli` ではなく headless の値を列挙したので、見慣れない entrypoint (`remote`、`claude-vscode`) はタイトルが付く側に転ぶ。
- **生成中、または直前に失敗したとき**。`<session_id>.pending` が両方を表す。5分で失効し、それが再試行の間隔になる。削除するのは成功時だけなので、失敗し続ける生成をプロンプトごとに呼ばない。kill された生成が置き去りにしたファイルも同じ仕組みで解消する。
- **再帰**。生成側ではフックを止めてあるので、`TITLE_HOOK_ACTIVE` は二重の防御。

## 生成側の呼び出し

`--model sonnet --no-session-persistence --strict-mcp-config --settings '{"disableAllHooks":true}'`

- **Sonnet** は切り詰めたプロンプトを Haiku より丁寧に読む。`Sidekiq のジョブが二重実行される問題を直したい` に対して、Haiku がキーワードまで削るのに対し Sonnet は `Sidekiqジョブ二重実行の修正` を返した。速さでも Sonnet が上で、`--strict-mcp-config` を両方に付けて3回ずつ測って 3.6秒 対 6.0秒。
- **`--strict-mcp-config`** は設定済みの MCP サーバ (figma, github, chrome) の起動を省く。サーバが温まった状態で Sonnet 同士、フラグ有り 3.6秒 / 無し 6〜7秒。コールドスタートでは30秒に達した回もある。
- **`disableAllHooks`** は入れ子の実行が設定済みのフックを全部発火させるのを止める。マーカーフックと無効なモデル名 (API に到達しない) で確認した。フラグ無しではマーカーが書かれる。つまり wip の `SessionStart` フックがタイトル生成の中で走り、その stdout が `additionalContext` として混ざる。`wip.md` があるブランチなら文書の全文と更新指示が入る。wakeguard のフックも発火していた。

ツールは有効のままにした。プロンプトが issue の URL と `これ対応して` だけ、という場面はよくあって、そのときタイトルは issue の本文から作るしかない。`https://github.com/ruby/ruby/issues/1` を投げると `Ruby TCP接続クローズ対応` が返った。全ツールを deny する案も試したが、この読み取りまで一緒に失う。代わりに生成側へ「読み取りだけをする」「ファイルの作成・編集・削除、git の操作、コメントの投稿など、状態を変える操作はしない」と伝えている。セッションに名前を付ける処理が副作用を持たないようにするため。1文目でファイル作成を命じるプロンプトで確かめたら、ファイルは作られず、タイトルは本題を表した。

## 取らなかった選択肢

- **`--bare`** は CLAUDE.md・プラグイン・フックを1フラグで飛ばせるが、認証を `ANTHROPIC_API_KEY` か `apiKeyHelper` からしか読まず keychain を見ない。このマシンは OAuth でログインしているので `claude -p --bare` は `Not logged in` で落ちる。
- **`--settings '{"claudeMdExcludes":[...]}'`** は `~/.claude/CLAUDE.md` (ペルソナ、「返答の半分は詩で終わる」) を生成から外せる。ただし詩はタイトルの後に来るので1行目の抽出で落ちるし、CLAUDE.md を移動するたびに glob を直すことになる。
- **フックの `once: true`** は pending ファイルの代わりになりそうに見えるが、削除処理は skill が実行時に登録したフックしか辿らない。`settings.json` で宣言したフックでは黙って無視される。
- **フックの timeout の明示**。`UserPromptSubmit` はコマンドフックの既定 timeout を30秒に下げる (2.1.233 の定数が `30000`、https://code.claude.com/docs/en/hooks にも記載)。フックは70msで返るので、書いても書かなくても何も縛らない。

## 間違えやすいところ

- 切り詰めは jq に任せてコードポイント単位で数える (プロンプトは `.[0:2000]`)。`head -c` はバイト単位なので、`Rails` + `あ`×40 を90バイトで切ると UTF-8 の途中で切れて U+FFFD になる。`cut -c` はフックのサブプロセスに `LC_CTYPE` の保証が無く、BSD cut が POSIX ロケールでバイトに落ちるため使わない。
- タイトルは空白以外の文字を含む最初の行を `grep -m1 '[^[:space:]]'` で取る。`grep -m1 .` は空白だけの行にも当たる。ランタイムは trim して捨てるので画面上は変わらないが、キャッシュに `"   "` が残って本物のタイトルが二度と生成されない。
- 40コードポイントを超える行は、切り詰めずに捨てて次回に回す。前置きや拒否文がタイトルとして固定されるのを防ぐため。長さの上限はこの1箇所だけ。
- タイトルは一時ファイルに書いて `mv` で置き換える。truncate 後・書き込み前のキャッシュを読み手が見ることはない。
- キャッシュディレクトリは symlink か他人の所有なら使わず、その後 `chmod` で 700 にする。`mkdir -m` のモードは作成時にしか効かず、既存の 0777 ディレクトリに対して `mkdir -p -m 700` は exit 0 で何も変えない。
- `session_id` は `[a-zA-Z0-9_-]` 以外を含んだら触らない。パスの一部に使うため。
- 切り離した生成は、`timeout` か `gtimeout` が PATH にあれば `timeout -k 10 180` の下で走る。無ければ上限なし。依存を増やさずに約束できるのはここまで。
- 生成側の stderr は `<session_id>.err` に落として成功時に消す。タイトルが付かなくなったときの手がかりを残すため。キャッシュファイルの掃除は OS に任せる。`$XDG_RUNTIME_DIR` はログアウトで消え、macOS はユーザーごとの `$TMPDIR` を消す。

## 確認したこと

payload を流した結果。新規セッションは生成を始めて 0.07秒で返る。生成中に来たプロンプトは何も返さない。次のプロンプトはキャッシュのタイトルを 0.07秒で返す。`session_title` を持つ payload は無出力でモデルを呼ばない。`CLAUDE_CODE_ENTRYPOINT=sdk-cli` はキャッシュも作らずに抜ける。`session_id` の無い payload は exit 0。

スタブの `claude` を PATH に置いた失敗系。生成が失敗するとき3プロンプトで呼び出しは1回に留まり、pending を過去の日時に打ち直してから投げると2回目を呼ぶ。60文字の行は捨てて再挑戦する。キャッシュディレクトリを symlink に差し替えると、リンク先に何も書かずに抜ける。既存の 0777 ディレクトリは `drwx------` になる。

実際の CLI と組み合わせた結果。`RSpec のテストが CI だけ落ちる原因を調べたい` → `CIだけ落ちるRSpec調査`。英語のプロンプトでも日本語のタイトルが返る。
