### PR TITLE
settings.json にデフォルトモデル opus[1m] を追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,6 +54,7 @@
       }
     }
   },
+  "model": "opus[1m]",
   "tui": "fullscreen",
   "editorMode": "vim",
   "remoteControlAtStartup": true,


### PR DESCRIPTION
`.claude/settings.json` に `"model": "opus[1m]"` を追加した。

## 背景

このマシンの `~/.claude/settings.json` が dotfiles への symlink ではなく実体ファイルになっていて、Claude Code の UI から変更した設定がリポジトリに入っていなかった。`itamae/roles/main.rb` には `.claude/settings.json` の symlink 定義が元々あるので、実体を消して symlink を張り直した (この操作自体はリポジトリの変更を伴わない)。

その際、ローカルの実体ファイルにしか無かったキーが 3 つあった。

- `"model": "opus[1m]"`
- `"env": {"CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1"}`
- `"preferredNotifChannel": "terminal_bell"`

このうち `model` だけを取り込む。取り込まないと、symlink に切り替えた後のセッションでモデルの指定が無い状態になるため。残り 2 つはリポジトリに入れない判断。

逆に dotfiles 側にあってローカルに無かったのは、`hooks.UserPromptSubmit` (`llm-session-title.sh`) と `enabledPlugins` の `security-guidance@claude-plugins-official` の 2 つで、symlink 化によりこのマシンでも効くようになる。`autoMode.environment` の差分は無視した。

## 置き場所

`tui` と `editorMode` の隣に置いた。権限やフックの設定ではなく、UI が書き込むセッション全体の好みという点で同じ種類の設定のため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L69gVJs5JbgMpKd85AELSu
